### PR TITLE
Lighweight count query

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 dist: xenial
 python:
-  - "3.9"
+  - "3.7"
 env:
-  - TOX_ENV=py39-django220
+  - TOX_ENV=py37-django22
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ install:
   - pip install tox
 notifications:
   email:
-    - jason.louard.ward@gmail.com
+    - product-team@policystat.com
 script: tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ dist: xenial
 python:
   - "3.7"
 env:
-  - TOX_ENV=py27-django111
-  - TOX_ENV=py37-django111
   - TOX_ENV=py37-django220
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 dist: xenial
 python:
-  - "3.7"
+  - "3.9"
 env:
-  - TOX_ENV=py37-django220
+  - TOX_ENV=py39-django220
 
 install:
   - pip install tox

--- a/django_tables/models.py
+++ b/django_tables/models.py
@@ -122,6 +122,8 @@ class ModelRows(Rows):
             data = self.table.data
             if isinstance(data, list):
                 self._length = len(self.table.data)
+            elif self.table.lightweight_data_count_query is not None:
+                self._length = self.table.lightweight_data_count_query.count()
             elif hasattr(data, 'count') and hasattr(data.count, '__call__'):
                 self._length = self.table.data.count()
             else:
@@ -173,7 +175,7 @@ class ModelTable(six.with_metaclass(ModelTableMetaclass, BaseTable)):
 
     rows_class = ModelRows
 
-    def __init__(self, data=None, *args, **kwargs):
+    def __init__(self, data=None, lightweight_data_count_query=None, *args, **kwargs):
         if data == []:
             data = None
         if data is None:
@@ -186,6 +188,7 @@ class ModelTable(six.with_metaclass(ModelTableMetaclass, BaseTable)):
             self.queryset = data._default_manager.all()
         else:
             self.queryset = data
+        self.lightweight_data_count_query = lightweight_data_count_query
 
         super(ModelTable, self).__init__(self.queryset, *args, **kwargs)
 

--- a/django_tables/models.py
+++ b/django_tables/models.py
@@ -122,10 +122,8 @@ class ModelRows(Rows):
             data = self.table.data
             if isinstance(data, list):
                 self._length = len(self.table.data)
-            elif self.table.lightweight_data_count_query is not None:
-                self._length = self.table.lightweight_data_count_query.count()
             elif hasattr(data, 'count') and hasattr(data.count, '__call__'):
-                self._length = self.table.data.count()
+                self._length = self.table.data.select_related(None).prefetch_related(None).count()  # noqa E501
             else:
                 self._length = len(list(self.table.data))
         return self._length
@@ -175,7 +173,7 @@ class ModelTable(six.with_metaclass(ModelTableMetaclass, BaseTable)):
 
     rows_class = ModelRows
 
-    def __init__(self, data=None, lightweight_data_count_query=None, *args, **kwargs):
+    def __init__(self, data=None, *args, **kwargs):
         if data == []:
             data = None
         if data is None:
@@ -188,7 +186,6 @@ class ModelTable(six.with_metaclass(ModelTableMetaclass, BaseTable)):
             self.queryset = data._default_manager.all()
         else:
             self.queryset = data
-        self.lightweight_data_count_query = lightweight_data_count_query
 
         super(ModelTable, self).__init__(self.queryset, *args, **kwargs)
 

--- a/django_tables/tests/test_models.py
+++ b/django_tables/tests/test_models.py
@@ -476,19 +476,3 @@ def test_with_a_list():
 
     countries = CountryTable(Country.objects.raw('SELECT * FROM country'))  # noqa
     assert countries.rows
-
-
-def test_lightweight_count_calculation_called():
-    class CountryTable(tables.ModelTable):
-        class Meta:
-            model = Country
-
-    lighthweight_count_query = Mock()
-    lighthweight_count_query.count = Mock(return_value=1)
-    countries = CountryTable(
-        data=None,
-        lightweight_data_count_query=lighthweight_count_query
-    )
-
-    assert len(countries.rows) == 1
-    assert lighthweight_count_query.count.called

--- a/django_tables/tests/test_models.py
+++ b/django_tables/tests/test_models.py
@@ -2,6 +2,7 @@
 
 Sets up a temporary Django project using a memory SQLite database.
 """
+from unittest.mock import Mock
 
 from nose.tools import assert_raises, assert_equal
 from django.conf import settings
@@ -475,3 +476,19 @@ def test_with_a_list():
 
     countries = CountryTable(Country.objects.raw('SELECT * FROM country'))  # noqa
     assert countries.rows
+
+
+def test_lightweight_count_calculation_called():
+    class CountryTable(tables.ModelTable):
+        class Meta:
+            model = Country
+
+    lighthweight_count_query = Mock()
+    lighthweight_count_query.count = Mock(return_value=1)
+    countries = CountryTable(
+        data=None,
+        lightweight_data_count_query=lighthweight_count_query
+    )
+
+    assert len(countries.rows) == 1
+    assert lighthweight_count_query.count.called

--- a/requirements-dev.pip
+++ b/requirements-dev.pip
@@ -1,3 +1,5 @@
-django
-nose
+django>=2.2, <2.3
+nose==1.3.7
+six>=1,<2
+django-nose>=1.4, <2
 Sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,7 @@
 
 [tox]
 envlist =
-    py27-django111,
-    py37-django{111,220}
+    py37-django22
 
 [testenv]
 commands = {envpython} run_tests.py
@@ -14,5 +13,4 @@ deps =
     nose
     django_nose
     six
-    django111: Django>=1.11, <1.12
-    django220: Django>=2.2, <2.3
+    django22: Django>=2.2, <2.3


### PR DESCRIPTION
We use the default query for calculating rows count.

Usually, it doesn't matter. However, in cases we provide composite query with inner joins which fetches data for a few tables, it could be a performance issue. And unnecessary load to a Database.

This PR provides an option for an alternative query for count only.