### PR TITLE
remove `python_2_unicode_compatible`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
+*~
+.DS\_Store
 *.pyc
+__pycache__/
 
-/MANIFEST
+/build
 /dist
 /docs/_build/*
-/build
+/MANIFEST
 
 /BRANCH_TODO
 
@@ -11,4 +14,6 @@
 /.project
 /.pydevproject
 /*.wpr
+
+.python-version
 .tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,19 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
-  - "3.10"
 env:
   - TOX_ENV=py37-django22
-
+  - TOX_ENV=py38-django22
+  - TOX_ENV=py39-django22
+  - TOX_ENV=py37-django30
+  - TOX_ENV=py38-django30
+  - TOX_ENV=py39-django30
+  - TOX_ENV=py37-django31
+  - TOX_ENV=py38-django31
+  - TOX_ENV=py39-django31
+  - TOX_ENV=py37-django32
+  - TOX_ENV=py38-django32
+  - TOX_ENV=py39-django32
 install:
   - pip install tox
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 dist: xenial
 python:
   - "3.7"
+  - "3.8"
+  - "3.9"
+  - "3.10"
 env:
   - TOX_ENV=py37-django22
 

--- a/django_tables/__init__.py
+++ b/django_tables/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (0, 7, 'dev')
+__version__ = (0, 8, 'dev')
 
 
 from .memory import *  # noqa

--- a/django_tables/base.py
+++ b/django_tables/base.py
@@ -5,7 +5,6 @@ from django.http import Http404
 from django.core import paginator
 from django.utils.encoding import force_text
 from django.utils.text import capfirst
-from django.utils.encoding import python_2_unicode_compatible
 
 import six
 
@@ -93,7 +92,6 @@ def toggleprefix(s):
     return ((s[:1] == '-') and [s[1:]] or ["-"+s])[0]
 
 
-@python_2_unicode_compatible
 class OrderByTuple(tuple):
     """Stores 'order by' instructions; Used to render output in a format
     we understand as input (see __str__) - especially useful in
@@ -273,7 +271,6 @@ class Columns(object):
         return self._columns[name]
 
 
-@python_2_unicode_compatible
 class BoundColumn(object):
     """
     'Runtime' version of ``Column`` that is bound to a table instance,
@@ -458,7 +455,6 @@ class Rows(object):
             raise TypeError('Key must be a slice or integer.')
 
 
-@python_2_unicode_compatible
 class BaseTable(six.with_metaclass(DeclarativeColumnsMetaclass)):
     """
     A collection of columns, plus their associated data rows.

--- a/django_tables/models.py
+++ b/django_tables/models.py
@@ -128,7 +128,7 @@ class ModelRows(Rows):
                 self._length = len(list(self.table.data))
         return self._length
 
-    # for compatibility with QuerySetPaginator
+    # for compatibility with django.core.paginator.Paginator
     count = __len__
 
 

--- a/django_tables/options.py
+++ b/django_tables/options.py
@@ -15,4 +15,6 @@ __all__ = ('options',)
 # raised instead.
 class DefaultOptions(object):
     IGNORE_INVALID_OPTIONS = True
+
+
 options = DefaultOptions()

--- a/django_tables/tests/__init__.py
+++ b/django_tables/tests/__init__.py
@@ -1,3 +1,4 @@
 # make django-tables available for import for tests
-import os, sys
+import os
+import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))

--- a/django_tables/tests/test_basic.py
+++ b/django_tables/tests/test_basic.py
@@ -46,6 +46,7 @@ def test_declaration():
     # modeltable hierarchy (both base class orders)
     class StateTable1(tables.ModelTable, GeoAreaTable):
         motto = tables.Column()
+
     class StateTable2(GeoAreaTable, tables.ModelTable):
         motto = tables.Column()
 
@@ -56,20 +57,21 @@ def test_declaration():
 
 def test_sort():
     class MyUnsortedTable(TestTable):
-        alpha  = tables.Column()
-        beta   = tables.Column()
-        n      = tables.Column()
+        alpha  = tables.Column()  # noqa
+        beta   = tables.Column()  # noqa
+        n      = tables.Column()  # noqa
 
     test_data = [
-        {'alpha': "mmm", 'beta': "mmm", 'n': 1 },
-        {'alpha': "aaa", 'beta': "zzz", 'n': 2 },
-        {'alpha': "zzz", 'beta': "aaa", 'n': 3 }]
+        {'alpha': "mmm", 'beta': "mmm", 'n': 1},
+        {'alpha': "aaa", 'beta': "zzz", 'n': 2},
+        {'alpha': "zzz", 'beta': "aaa", 'n': 3},
+    ]
 
     # various different ways to say the same thing: don't sort
-    assert_equal(MyUnsortedTable(test_data               ).order_by, ())
+    assert_equal(MyUnsortedTable(test_data).order_by, ())
     assert_equal(MyUnsortedTable(test_data, order_by=None).order_by, ())
-    assert_equal(MyUnsortedTable(test_data, order_by=[]  ).order_by, ())
-    assert_equal(MyUnsortedTable(test_data, order_by=()  ).order_by, ())
+    assert_equal(MyUnsortedTable(test_data, order_by=[]).order_by, ())
+    assert_equal(MyUnsortedTable(test_data, order_by=()).order_by, ())
 
     # values of order_by are wrapped in tuples before being returned
     assert_equal(('alpha',), MyUnsortedTable([], order_by='alpha').order_by)
@@ -120,8 +122,8 @@ def test_pagination():
 
     # create some sample data
     data = []
-    for i in range(1,101):
-        data.append({'name': 'Book Nr. %d'%i})
+    for i in range(1, 101):
+        data.append({'name': 'Book Nr. %d' % i})
     books = BookTable(data)
 
     # external paginator
@@ -129,8 +131,8 @@ def test_pagination():
     assert paginator.num_pages == 10
     page = paginator.page(1)
     assert len(page.object_list) == 10
-    assert page.has_previous() == False
-    assert page.has_next() == True
+    assert page.has_previous() is False
+    assert page.has_next() is True
 
     # integrated paginator
     books.paginate(Paginator, 10, page=1)
@@ -139,8 +141,8 @@ def test_pagination():
     assert len(list(books.rows.all())) == 100
     # new attributes
     assert books.paginator.num_pages == 10
-    assert books.page.has_previous() == False
-    assert books.page.has_next() == True
+    assert books.page.has_previous() is False
+    assert books.page.has_next() is True
     # exceptions are converted into 404s
     assert_raises(Http404, books.paginate, Paginator, 10, page=9999)
     assert_raises(Http404, books.paginate, Paginator, 10, page="abc")

--- a/django_tables/tests/test_memory.py
+++ b/django_tables/tests/test_memory.py
@@ -4,9 +4,7 @@ TODO: A bunch of those tests probably fit better into test_basic, since
 they aren't really MemoryTable specific.
 """
 
-from math import sqrt
 from nose.tools import assert_raises
-from django.core.paginator import Paginator
 import django_tables as tables
 
 
@@ -32,13 +30,13 @@ def test_basic():
     for r in stuff.rows:
         # unknown fields are removed/not-accessible
         assert 'name' in r
-        assert not 'id' in r
+        assert 'id' not in r
         # missing data is available as default
         assert 'answer' in r
-        assert r['answer'] == 42   # note: different from prev. line!
+        assert r['answer'] == 42  # note: different from prev. line!
 
         # all that still works when name overrides are used
-        assert not 'c' in r
+        assert 'c' not in r
         assert 'count' in r
         assert r['count'] == 1
 
@@ -56,13 +54,13 @@ def test_basic():
     # changing an instance's base_columns does not change the class
     assert id(stuff.base_columns) != id(StuffTable.base_columns)
     stuff.base_columns['test'] = tables.Column()
-    assert not 'test' in StuffTable.base_columns
+    assert 'test' not in StuffTable.base_columns
 
     # optionally, exceptions can be raised when input is invalid
     tables.options.IGNORE_INVALID_OPTIONS = False
     try:
-        assert_raises(ValueError, setattr, stuff, 'order_by', '-name,made-up-column')
-        assert_raises(ValueError, setattr, stuff, 'order_by', ('made-up-column',))
+        assert_raises(ValueError, setattr, stuff, 'order_by', '-name,made-up-column')  # noqa E501
+        assert_raises(ValueError, setattr, stuff, 'order_by', ('made-up-column',))  # noqa E501
         # when a column name is overwritten, the original won't work anymore
         assert_raises(ValueError, setattr, stuff, 'order_by', 'c')
         # reset for future tests
@@ -71,12 +69,12 @@ def test_basic():
 
 
 class TestRender:
-    """Test use of the render_* methods.
-    """
+    """Test use of the render_* methods."""
 
     def test(self):
         class TestTable(tables.MemoryTable):
             public_name = tables.Column(model_rel='private_name')
+
             def render_public_name(self, data):
                 # We are given the actual data dict and have direct access
                 # to additional values for which no field is defined.
@@ -86,14 +84,15 @@ class TestRender:
         assert table.rows[0]['public_name'] == 'FOO:BAR'
 
     def test_not_sorted(self):
-        """The render methods are not considered when sorting.
-        """
+        """The render methods are not considered when sorting."""
         class TestTable(tables.MemoryTable):
             foo = tables.Column()
+
             def render_foo(self, data):
                 return -data['foo']  # try to cause a reverse sort
         table = TestTable([{'foo': 1}, {'foo': 2}], order_by='asc')
-        # Result is properly sorted, and the render function has never been called
+        # Result is properly sorted
+        # and the render function has never been called
         assert [r['foo'] for r in table.rows] == [-1, -2]
 
 
@@ -105,15 +104,17 @@ def test_meta_sortable():
             id = tables.Column(sortable=True)
             name = tables.Column(sortable=False)
             author = tables.Column()
+
             class Meta:
                 sortable = default_sortable
+
         return BookTable([])
 
     global_table = mktable(None)
     for default_sortable, results in (
-        (None,      (True, False, True)),    # last bool is global default
-        (True,      (True, False, True)),    # last bool is table default
-        (False,     (True, False, False)),   # last bool is table default
+        (None,  (True, False, True)),   # last bool is global default
+        (True,  (True, False, True)),   # last bool is table default
+        (False, (True, False, False)),  # last bool is table default
     ):
         books = mktable(default_sortable)
         assert [c.sortable for c in books.columns] == list(results)
@@ -129,15 +130,29 @@ def test_sort():
         id = tables.Column(direction='desc')
         name = tables.Column()
         num_pages = tables.Column(model_rel='pages')  # test rewritten names
-        language = tables.Column(default='en')   # default affects sorting
-        rating = tables.Column(model_rel='*')         # test data field option
+        language = tables.Column(default='en')  # default affects sorting
+        rating = tables.Column(model_rel='*')  # test data field option
 
-    books = BookTable([
-        {'id': 1, 'pages':  60, 'name': 'Z: The Book', '*': 5},    # language: en
-        {'id': 2, 'pages': 100, 'language': 'de', 'name': 'A: The Book', '*': 2},
-        {'id': 3, 'pages':  80, 'language': 'de', 'name': 'A: The Book, Vol. 2', '*': 4},
-        {'id': 4, 'pages': 110, 'language': 'fr', 'name': 'A: The Book, French Edition', '*': 1},   # rating (with data option) is missing
-    ])
+    books = BookTable(
+        [
+            {'id': 1, 'pages': 60, 'name': 'Z: The Book', '*': 5},  # noqa E501 language: en
+            {'id': 2, 'pages': 100, 'language': 'de', 'name': 'A: The Book', '*': 2},  # noqa E501
+            {
+                'id': 3,
+                'pages': 80,
+                'language': 'de',
+                'name': 'A: The Book, Vol. 2',
+                '*': 4,
+            },
+            {
+                'id': 4,
+                'pages': 110,
+                'language': 'fr',
+                'name': 'A: The Book, French Edition',
+                '*': 1,
+            },  # rating (with data option) is missing
+        ]
+    )
 
     # None is normalized to an empty order by tuple, ensuring iterability;
     # it also supports all the cool methods that we offer for order_by.
@@ -155,27 +170,28 @@ def test_sort():
     def test_order(order, result):
         books.order_by = order
         assert [b['id'] for b in books.rows] == result
-    test_order(('num_pages',), [1,3,2,4])
-    test_order(('-num_pages',), [4,2,3,1])
-    test_order(('name',), [2,4,3,1])
-    test_order(('language', 'num_pages'), [3,2,1,4])
+
+    test_order(('num_pages',), [1, 3, 2, 4])
+    test_order(('-num_pages',), [4, 2, 3, 1])
+    test_order(('name',), [2, 4, 3, 1])
+    test_order(('language', 'num_pages'), [3, 2, 1, 4])
     # using a simple string (for convinience as well as querystring passing
-    test_order('-num_pages', [4,2,3,1])
-    test_order('language,num_pages', [3,2,1,4])
+    test_order('-num_pages', [4, 2, 3, 1])
+    test_order('language,num_pages', [3, 2, 1, 4])
     # if overwritten, the declared fieldname has no effect
-    test_order('pages,name', [2,4,3,1])   # == ('name',)
+    test_order('pages,name', [2, 4, 3, 1])  # == ('name',)
     # sort by column with "data" option
-    test_order('rating', [4,2,3,1])
+    test_order('rating', [4, 2, 3, 1])
 
     # test the column with a default ``direction`` set to descending
-    test_order('id', [4,3,2,1])
-    test_order('-id', [1,2,3,4])
+    test_order('id', [4, 3, 2, 1])
+    test_order('-id', [1, 2, 3, 4])
     # changing the direction afterwards is fine too
     books.base_columns['id'].direction = 'asc'
-    test_order('id', [1,2,3,4])
-    test_order('-id', [4,3,2,1])
+    test_order('id', [1, 2, 3, 4])
+    test_order('-id', [4, 3, 2, 1])
     # a invalid direction string raises an exception
-    assert_raises(ValueError, setattr, books.base_columns['id'], 'direction', 'blub')
+    assert_raises(ValueError, setattr, books.base_columns['id'], 'direction', 'blub')  # noqa E501
 
     # [bug] test alternative order formats if passed to constructor
     BookTable([], 'language,-num_pages')
@@ -186,7 +202,7 @@ def test_sort():
     books.base_columns['language'].sortable = False
     books.order_by = 'language'
     assert not books.order_by
-    test_order(('language', 'num_pages'), [1,3,2,4])  # as if: 'num_pages'
+    test_order(('language', 'num_pages'), [1, 3, 2, 4])  # as if: 'num_pages'
 
     # [bug] order_by did not run through setter when passed to init
     books = BookTable([], order_by='name')
@@ -209,54 +225,59 @@ def test_sort():
     assert 'name' in books.order_by
     books.order_by = '-name'
     assert 'name' in books.order_by
-    assert not 'language' in books.order_by
+    assert 'language' not in books.order_by
 
 
 def test_callable():
-    """Data fields and the ``default`` option can be callables.
-    """
+    """Data fields and the ``default`` option can be callables."""
 
     class MathTable(tables.MemoryTable):
         lhs = tables.Column()
         rhs = tables.Column()
         op = tables.Column(default='+')
-        sum = tables.Column(default=lambda d: calc(d['op'], d['lhs'], d['rhs']))
+        sum = tables.Column(default=lambda d: calc(d['op'], d['lhs'], d['rhs']))  # noqa E501
 
-    math = MathTable([
-        {'lhs': 1, 'rhs': lambda x: x['lhs']*3},              # 1+3
-        {'lhs': 9, 'rhs': lambda x: x['lhs'], 'op': '/'},     # 9/9
-        {'lhs': lambda x: x['rhs']+3, 'rhs': 4, 'op': '-'},   # 7-4
-    ])
+    math = MathTable(
+        [
+            {'lhs': 1, 'rhs': lambda x: x['lhs'] * 3},             # 1+3
+            {'lhs': 9, 'rhs': lambda x: x['lhs'], 'op': '/'},      # 9/9
+            {'lhs': lambda x: x['rhs'] + 3, 'rhs': 4, 'op': '-'},  # 7-4
+        ]
+    )
 
     # function is called when queried
     def calc(op, lhs, rhs):
-        if op == '+': return lhs+rhs
-        elif op == '/': return lhs/rhs
-        elif op == '-': return lhs-rhs
-    assert [calc(row['op'], row['lhs'], row['rhs']) for row in math] == [4,1,3]
+        if op == '+':
+            return lhs + rhs
+        elif op == '/':
+            return lhs / rhs
+        elif op == '-':
+            return lhs - rhs
+
+    assert [calc(row['op'], row['lhs'], row['rhs']) for row in math] == [4, 1, 3]  # noqa E501
 
     # field function is called while sorting
     math.order_by = ('-rhs',)
-    assert [row['rhs'] for row in math] == [9,4,3]
+    assert [row['rhs'] for row in math] == [9, 4, 3]
 
     # default function is called while sorting
     math.order_by = ('sum',)
-    assert [row['sum'] for row in math] == [1,3,4]
+    assert [row['sum'] for row in math] == [1, 3, 4]
 
 
 # TODO: all the column stuff might warrant it's own test file
 def test_columns():
-    """Test Table.columns container functionality.
-    """
+    """Test Table.columns container functionality."""
 
     class BookTable(tables.MemoryTable):
         id = tables.Column(sortable=False, visible=False)
         name = tables.Column(sortable=True)
         pages = tables.Column(sortable=True)
         language = tables.Column(sortable=False)
+
     books = BookTable([])
 
-    assert list(books.columns.sortable()) == [c for c in books.columns if c.sortable]
+    assert list(books.columns.sortable()) == [c for c in books.columns if c.sortable]  # noqa E501
 
     # .columns iterator only yields visible columns
     assert len(list(books.columns)) == 3
@@ -266,63 +287,138 @@ def test_columns():
 
 
 def test_column_order():
-    """Test the order functionality of bound columns.
-    """
+    """Test the order functionality of bound columns."""
 
     class BookTable(tables.MemoryTable):
         id = tables.Column()
         name = tables.Column()
         pages = tables.Column()
         language = tables.Column()
+
     books = BookTable([])
 
     # the basic name property is a no-brainer
     books.order_by = ''
-    assert [c.name for c in books.columns] == ['id','name','pages','language']
+    assert [c.name for c in books.columns] == ['id', 'name', 'pages', 'language']  # noqa E501
 
     # name_reversed will always reverse, no matter what
     for test in ['', 'name', '-name']:
         books.order_by = test
-        assert [c.name_reversed for c in books.columns] == ['-id','-name','-pages','-language']
+        assert [c.name_reversed for c in books.columns] == [
+            '-id',
+            '-name',
+            '-pages',
+            '-language',
+        ]
 
     # name_toggled will always toggle
     books.order_by = ''
-    assert [c.name_toggled for c in books.columns] == ['id','name','pages','language']
+    assert [c.name_toggled for c in books.columns] == [
+        'id',
+        'name',
+        'pages',
+        'language',
+    ]
     books.order_by = 'id'
-    assert [c.name_toggled for c in books.columns] == ['-id','name','pages','language']
+    assert [c.name_toggled for c in books.columns] == [
+        '-id',
+        'name',
+        'pages',
+        'language',
+    ]
     books.order_by = '-name'
-    assert [c.name_toggled for c in books.columns] == ['id','name','pages','language']
+    assert [c.name_toggled for c in books.columns] == [
+        'id',
+        'name',
+        'pages',
+        'language',
+    ]
     # other columns in an order_by will be dismissed
     books.order_by = '-id,name'
-    assert [c.name_toggled for c in books.columns] == ['id','-name','pages','language']
+    assert [c.name_toggled for c in books.columns] == [
+        'id',
+        '-name',
+        'pages',
+        'language',
+    ]
 
     # with multi-column order, this is slightly more complex
-    books.order_by =  ''
-    assert [str(c.order_by) for c in books.columns] == ['id','name','pages','language']
-    assert [str(c.order_by_reversed) for c in books.columns] == ['-id','-name','-pages','-language']
-    assert [str(c.order_by_toggled) for c in books.columns] == ['id','name','pages','language']
-    books.order_by =  'id'
-    assert [str(c.order_by) for c in books.columns] == ['id','id,name','id,pages','id,language']
-    assert [str(c.order_by_reversed) for c in books.columns] == ['-id','id,-name','id,-pages','id,-language']
-    assert [str(c.order_by_toggled) for c in books.columns] == ['-id','id,name','id,pages','id,language']
-    books.order_by =  '-pages,id'
-    assert [str(c.order_by) for c in books.columns] == ['-pages,id','-pages,id,name','pages,id','-pages,id,language']
-    assert [str(c.order_by_reversed) for c in books.columns] == ['-pages,-id','-pages,id,-name','-pages,id','-pages,id,-language']
-    assert [str(c.order_by_toggled) for c in books.columns] == ['-pages,-id','-pages,id,name','pages,id','-pages,id,language']
+    books.order_by = ''
+    assert [str(c.order_by) for c in books.columns] == [
+        'id',
+        'name',
+        'pages',
+        'language',
+    ]
+    assert [str(c.order_by_reversed) for c in books.columns] == [
+        '-id',
+        '-name',
+        '-pages',
+        '-language',
+    ]
+    assert [str(c.order_by_toggled) for c in books.columns] == [
+        'id',
+        'name',
+        'pages',
+        'language',
+    ]
+    books.order_by = 'id'
+    assert [str(c.order_by) for c in books.columns] == [
+        'id',
+        'id,name',
+        'id,pages',
+        'id,language',
+    ]
+    assert [str(c.order_by_reversed) for c in books.columns] == [
+        '-id',
+        'id,-name',
+        'id,-pages',
+        'id,-language',
+    ]
+    assert [str(c.order_by_toggled) for c in books.columns] == [
+        '-id',
+        'id,name',
+        'id,pages',
+        'id,language',
+    ]
+    books.order_by = '-pages,id'
+    assert [str(c.order_by) for c in books.columns] == [
+        '-pages,id',
+        '-pages,id,name',
+        'pages,id',
+        '-pages,id,language',
+    ]
+    assert [str(c.order_by_reversed) for c in books.columns] == [
+        '-pages,-id',
+        '-pages,id,-name',
+        '-pages,id',
+        '-pages,id,-language',
+    ]
+    assert [str(c.order_by_toggled) for c in books.columns] == [
+        '-pages,-id',
+        '-pages,id,name',
+        'pages,id',
+        '-pages,id,language',
+    ]
 
     # querying whether a column is ordered is possible
     books.order_by = ''
-    assert [c.is_ordered for c in books.columns] == [False, False, False, False]
+    assert [c.is_ordered for c in books.columns] == [False, False, False, False]  # noqa E501
     books.order_by = 'name'
     assert [c.is_ordered for c in books.columns] == [False, True, False, False]
-    assert [c.is_ordered_reverse for c in books.columns] == [False, False, False, False]
-    assert [c.is_ordered_straight for c in books.columns] == [False, True, False, False]
+    assert [c.is_ordered_reverse for c in books.columns] == [False, False, False, False]  # noqa E501
+    assert [c.is_ordered_straight for c in books.columns] == [False, True, False, False]  # noqa E501
     books.order_by = '-pages'
     assert [c.is_ordered for c in books.columns] == [False, False, True, False]
-    assert [c.is_ordered_reverse for c in books.columns] == [False, False, True, False]
-    assert [c.is_ordered_straight for c in books.columns] == [False, False, False, False]
+    assert [c.is_ordered_reverse for c in books.columns] == [False, False, True, False]  # noqa E501
+    assert [c.is_ordered_straight for c in books.columns] == [
+        False,
+        False,
+        False,
+        False,
+    ]
     # and even works with multi-column ordering
     books.order_by = 'id,-pages'
     assert [c.is_ordered for c in books.columns] == [True, False, True, False]
-    assert [c.is_ordered_reverse for c in books.columns] == [False, False, True, False]
-    assert [c.is_ordered_straight for c in books.columns] == [True, False, False, False]
+    assert [c.is_ordered_reverse for c in books.columns] == [False, False, True, False]  # noqa E501
+    assert [c.is_ordered_straight for c in books.columns] == [True, False, False, False]  # noqa E501

--- a/django_tables/tests/test_models.py
+++ b/django_tables/tests/test_models.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 
 from nose.tools import assert_raises, assert_equal
 from django.conf import settings
-from django.core.paginator import Paginator, QuerySetPaginator
+from django.core.paginator import Paginator
 import django_tables as tables
 from django_tables.tests.testapp.models import City, Country
 
@@ -420,8 +420,7 @@ def test_pagination():
     # queries, one a count(). This check is far from foolproof...
     assert len(connection.queries)-start_querycount == 2
 
-    # using a queryset paginator is possible as well (although unnecessary)
-    paginator = QuerySetPaginator(cities.rows, 10)
+    paginator = Paginator(cities.rows, 10)
     assert paginator.num_pages == 10
 
     # integrated paginator

--- a/django_tables/tests/test_models.py
+++ b/django_tables/tests/test_models.py
@@ -2,13 +2,12 @@
 
 Sets up a temporary Django project using a memory SQLite database.
 """
-from unittest.mock import Mock
-
-from nose.tools import assert_raises, assert_equal
 from django.conf import settings
 from django.core.paginator import Paginator
-import django_tables as tables
 from django_tables.tests.testapp.models import City, Country
+from nose.tools import assert_raises, assert_equal
+
+import django_tables as tables
 
 
 def setup_module(module):

--- a/docs/features/pagination.rst
+++ b/docs/features/pagination.rst
@@ -18,7 +18,7 @@ You're not necessarily restricted to Django's own paginator (or subclasses) -
 any paginator should work with this approach, so long it only requires
 ``rows`` to implement ``len()``, slicing, and, in the case of a
 ``ModelTable``, a ``count()`` method. The latter means that the
-``QuerySetPaginator`` also works as expected.
+``django.core.paginator.Paginator`` also works as expected.
 
 Alternatively, you may use the ``paginate`` feature:
 
@@ -41,7 +41,7 @@ as it follows the Django protocol:
   attribute, exposing the paginated data.
 
 Note that due to the abstraction layer that ``django-tables`` represents, it
-is not necessary to use Django's ``QuerySetPaginator`` with model tables.
+is not necessary to use Django's ``django.core.paginator.Paginator`` with model tables.
 Since the table knows that it holds a queryset, it will automatically choose
 to use count() to determine the data length (which is exactly what
-``QuerySetPaginator`` would do).
+``django.core.paginator.Paginator`` would do).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -85,7 +85,7 @@ template:
     def list_countries(request):
         data = ...
         countries = CountryTable(data, order_by=request.GET.get('sort', 'name'))
-        return render_to_response('list.html', {'table': countries})
+        return render(request, 'list.html', {'table': countries})
 
 Note that we are giving the incoming ``sort`` query string value directly to
 the table, asking for a sort. All invalid column names will (by default) be
@@ -146,4 +146,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/requirements-dev.pip
+++ b/requirements-dev.pip
@@ -1,4 +1,4 @@
-django>=2.2
+django>=2.2, <2.3
 nose==1.3.7
 six>=1,<2
 django-nose>=1.4, <2

--- a/requirements-dev.pip
+++ b/requirements-dev.pip
@@ -1,4 +1,4 @@
-django>=2.2, <2.3
+django>=2.2
 nose==1.3.7
 six>=1,<2
 django-nose>=1.4, <2

--- a/run_tests.py
+++ b/run_tests.py
@@ -44,5 +44,6 @@ def runtests():
     argv = sys.argv[:1] + ['test', 'django_tables', '--traceback'] + sys.argv[1:]  # noqa
     execute_from_command_line(argv)
 
+
 if __name__ == '__main__':
     runtests()

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ from distutils.core import setup
 # which may not be the case when processing a pip requirements
 # file, for example.
 import re
+
 here = os.path.dirname(os.path.abspath(__file__))
-version_re = re.compile(
-    r'__version__ = (\(.*?\))')
+version_re = re.compile(r'__version__ = (\(.*?\))')
 fp = open(os.path.join(here, 'django_tables', '__init__.py'))
 version = None
 for line in fp:
@@ -33,14 +33,14 @@ def find_packages(root):
 
 
 setup(
-    name = 'django-tables',
+    name='django-tables',
     version=".".join(map(str, version)),
-    description = 'Render QuerySets as tabular data in Django.',
-    author = 'Michael Elsdoerfer',
-    author_email = 'michael@elsdoerfer.info',
-    license = 'BSD',
-    url = 'http://launchpad.net/django-tables',
-    classifiers = [
+    description='Render QuerySets as tabular data in Django.',
+    author='Michael Elsdoerfer',
+    author_email='michael@elsdoerfer.info',
+    license='BSD',
+    url='http://launchpad.net/django-tables',
+    classifiers=[
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',
         'Framework :: Django',
@@ -50,6 +50,6 @@ setup(
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Libraries',
-        ],
-    packages = find_packages('django_tables'),
+    ],
+    packages=find_packages('django_tables'),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 envlist =
-    py37-django22
+    py{37,38,39}-django{22,30,31,32}
 
 [testenv]
 commands = {envpython} run_tests.py
@@ -14,3 +14,6 @@ deps =
     django_nose
     six
     django22: Django>=2.2, <2.3
+    django30: Django>=3.0, <3.1
+    django31: Django>=3.1, <3.2
+    django32: Django>=3.2, <3.3

--- a/tox.ini
+++ b/tox.ini
@@ -13,4 +13,4 @@ deps =
     nose
     django_nose
     six
-    django22: Django>=2.2, <2.3
+    django22: Django>=2.2

--- a/tox.ini
+++ b/tox.ini
@@ -13,4 +13,4 @@ deps =
     nose
     django_nose
     six
-    django22: Django>=2.2
+    django22: Django>=2.2, <2.3


### PR DESCRIPTION
Closes #7 

*  [Django 3.0 deprecations](https://docs.djangoproject.com/en/3.2/internals/deprecation/#deprecation-removed-in-3-0):
 * See the Django 2.0 release notes for more details on these changes.
- [x] The django.db.backends.postgresql_psycopg2 module will be removed.
- [x] django.shortcuts.render_to_response() will be removed.
- [x] The DEFAULT_CONTENT_TYPE setting will be removed.
- [x] HttpRequest.xreadlines() will be removed.
- [x] Support for the context argument of Field.from_db_value() and Expression.convert_value() will be removed.
- [x] The field_name keyword argument of QuerySet.earliest() and latest() will be removed.
 * See the Django 2.1 release notes for more details on these changes.
- [x] django.contrib.gis.db.models.functions.ForceRHR will be removed.
- [x] django.utils.http.cookie_date() will be removed.
- [x] The staticfiles and admin_static template tag libraries will be removed.
- [x] django.contrib.staticfiles.templatetags.static() will be removed.
- [x] The shim to allow InlineModelAdmin.has_add_permission() to be defined without an obj argument will be removed.

*  [Django 3.1 deprecations](https://docs.djangoproject.com/en/3.2/internals/deprecation/#deprecation-removed-in-3-1):
* See the Django 2.2 release notes for more details on these changes.
 - [x] django.utils.timezone.FixedOffset will be removed.
 - [x] django.core.paginator.QuerySetPaginator will be removed.
 - [x] A model’s Meta.ordering will no longer affect GROUP BY queries.
 - [x] django.contrib.postgres.fields.FloatRangeField and django.contrib.postgres.forms.FloatRangeField will be removed.
 - [x] The FILE_CHARSET setting will be removed.
 - [x] django.contrib.staticfiles.storage.CachedStaticFilesStorage will be removed.
 - [x] RemoteUserBackend.configure_user() will require request as the first positional argument.
 - [x] Support for SimpleTestCase.allow_database_queries and TransactionTestCase.multi_db will be removed.