### PR TITLE
Upgrade django-tables for Django 4.2 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ __pycache__/
 
 .python-version
 .tox/
+
+*.egg-info/

--- a/django_tables/__init__.py
+++ b/django_tables/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (0, 8, 'dev')
+__version__ = (0, 9, 'dev')
 
 
 from .memory import *  # noqa

--- a/django_tables/base.py
+++ b/django_tables/base.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 
 from django.http import Http404
 from django.core import paginator
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.text import capfirst
 
 import six
@@ -341,7 +341,7 @@ class BoundColumn(object):
 
     def __str__(self):
         s = self.column.verbose_name or self.name.replace('_', ' ')
-        return capfirst(force_text(s))
+        return capfirst(force_str(s))
 
     def as_html(self):
         pass

--- a/requirements-dev.pip
+++ b/requirements-dev.pip
@@ -1,4 +1,4 @@
-django>=2.2, <2.3
+django>=2.2, <4.3
 nose==1.3.7
 six>=1,<2
 django-nose>=1.4, <2

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,8 @@
 
 [tox]
 envlist =
-    py{37,38,39}-django{22,30,31,32}
+	py37-django2.2
+    py{38,39}-django{30,31,32,40,41,42}
 
 [testenv]
 commands = {envpython} run_tests.py
@@ -13,7 +14,10 @@ deps =
     nose
     django_nose
     six
-    django22: Django>=2.2, <2.3
+    django2.2: Django>=2.2, <2.3
     django30: Django>=3.0, <3.1
     django31: Django>=3.1, <3.2
     django32: Django>=3.2, <3.3
+    django40: Django>=4.0, <4.1
+    django41: Django>=4.1, <4.2
+    django42: Django>=4.2, <4.3


### PR DESCRIPTION
Compatibility fixes for Django 4.2

## Django 4.0.10
* [Django 4.0 deprecations](https://docs.djangoproject.com/en/5.0/internals/deprecation/#deprecation-removed-in-4-0):
* See the [Django 3.0 release notes](https://docs.djangoproject.com/en/5.0/releases/3.0/#deprecated-features-3-0) for more details on these changes.

- [x] **django.utils.encoding.force_text()** and **smart_text()** will be removed.  The aliases are  force_str() and smart_str().
- [x] **django.utils.http.urlquote()**, **urlquote_plus()**, **urlunquote()**, and **urlunquote_plus()** will be removed.
- [x] **django.utils.translation.ugettext()**, **ugettext_lazy()**, **ugettext_noop()**, **ungettext()**, and **ungettext_lazy()** will be removed.
- [x] **django.views.i18n.set_language()** will no longer set the user language in **request.session** (key **django.utils.translation.LANGUAGE_SESSION_KEY**). 
- [x] **alias=None** will be required in the signature of **django.db.models.Expression.get_group_by_cols()** subclasses.
- [x] **django.utils.text.unescape_entities()** will be removed.
- [x] **django.utils.http.is_safe_url()** will be removed.

* See the [Django 3.1 release notes](https://docs.djangoproject.com/en/5.0/releases/3.1/#deprecated-features-3-1) for more details on these changes.
- [x] **The PASSWORD_RESET_TIMEOUT_DAYS** setting will be removed.
- [x] The undocumented usage of the **isnull** lookup with non-boolean values as the right-hand side will no longer be allowed.
- [x] The **django.db.models.query_utils.InvalidQuery** exception class will be removed.
- [x] The **django-admin.py** entry point will be removed.
- [x] Support for the pre-Django 3.1 encoding format of cookies values used by **django.contrib.messages.storage.cookie.CookieStorage** will be removed.
- [x] The **providing_args** argument for **django.dispatch.Signal** will be removed.
- [x] The **length** argument for **django.utils.crypto.get_random_string()** will be required.
- [x] The model **NullBooleanField** will be removed. A stub field will remain for compatibility with historical migrations. 
- [x] The model **django.contrib.postgres.fields.JSONField** will be removed. A stub field will remain for compatibility with historical migrations.
- [x] **django.contrib.postgres.forms.JSONField**, **django.contrib.postgres.fields.jsonb.KeyTransform**, and **django.contrib.postgres.fields.jsonb.KeyTextTransform** will be removed.
- [x] The **DEFAULT_HASHING_ALGORITHM** transitional setting will be removed.
- [x] Support for passing raw column aliases to **QuerySet.order_by()** will be removed.
- [x] **django.conf.urls.url()** will be removed.  It's an alias of **django.urls.re_path()**.
- [x] The **get_response** argument for **django.utils.deprecation.MiddlewareMixin.__init__()** will be required and won’t accept **None**.
- [x] The **list** message for **ModelMultipleChoiceField** will be removed.
- [x] The **HttpRequest.is_ajax()** method will be removed.
- [x] The **{% ifequal %}** and **{% ifnotequal %}** template tags will be removed.

### pre-Django 3.1 SHA-1
- [x] Support for the pre-Django 3.1 password reset tokens in the admin site (that use the SHA-1 hashing algorithm) will be removed.
- [x] Support for the pre-Django 3.1 encoding format of sessions will be removed.
- [x] Support for the pre-Django 3.1 **django.core.signing.Signer** signatures (encoded with the SHA-1 algorithm) will be removed.
- [x] Support for the pre-Django 3.1 **django.core.signing.dumps()** signatures (encoded with the SHA-1 algorithm) in **django.core.signing.loads()** will be removed.
- [x] Support for the pre-Django 3.1 user sessions (that use the SHA-1 algorithm) will be removed.

## Django 4.1.13
See the [Django 3.2 release notes](https://docs.djangoproject.com/en/5.0/releases/3.2/#deprecated-features-3-2) for more details on these changes.

- [x] Support for assigning objects which don’t support creating deep copies with **copy.deepcopy()** to class attributes in **TestCase.setUpTestData()** will be removed.
- [x] The **whitelist** argument and **domain_whitelist** attribute of **django.core.validators.EmailValidator** will be removed.
- [x] **TransactionTestCase.assertQuerysetEqual()** will no longer automatically call **repr()** on a queryset when compared to string values.
- [x] Support for the pre-Django 3.2 format of messages used by **django.contrib.messages.storage.cookie.CookieStorage** will be removed.
- [x] **BaseCommand.requires_system_checks** won’t support boolean values. Use '__all__' instead of True, and [] (an empty list) instead of False.
- [x] **django.core.cache.backends.memcached.MemcachedCache** will be removed.
- [x] The **default_app_config** module variable will be removed. 


## Unit Testing
- [x] Verify unit tests pass when running `tox` with the new testing environment configuration in place.
